### PR TITLE
Feat | 마네킹 이상현상 눈색깔 변경 기능 추가 및 게임 시스템 일부 변경

### DIFF
--- a/Assets/Scenes/Abnormol Phenomenon/Mannequin/EyeColorRed.mat
+++ b/Assets/Scenes/Abnormol Phenomenon/Mannequin/EyeColorRed.mat
@@ -1,0 +1,126 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: EyeColorRed
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 0.70440245, g: 0, b: 0, a: 1}
+    - _Color: {r: 0.70440245, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []
+--- !u!114 &2751671506873905607
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5

--- a/Assets/Scenes/Abnormol Phenomenon/Mannequin/EyeColorRed.mat.meta
+++ b/Assets/Scenes/Abnormol Phenomenon/Mannequin/EyeColorRed.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9a04d1f8efa3504abde6b631f9be4ad
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ActivateMannequin.cs
+++ b/Assets/Scripts/ActivateMannequin.cs
@@ -6,8 +6,12 @@ public class ActivateMannequin : MonoBehaviour
 {
     public GameObject Player;
     public float ActivationDistance = 50f; // 애니메이션 작동 범위
+    public GameObject[] MannequinEyes = new GameObject[2];
+    public Material[] MannequinEyesMaterial = new Material[2];
     bool isAnimationActivated = false;
     private Animator MannequinAnimator;
+    private Renderer LeftMERenderer;
+    private Renderer RightMERenderer;
 
     void Start()
     {
@@ -18,6 +22,8 @@ public class ActivateMannequin : MonoBehaviour
     {
         isAnimationActivated = false;
         MannequinAnimator = GetComponent<Animator>();
+        LeftMERenderer = MannequinEyes[0].GetComponent<Renderer>();
+        RightMERenderer = MannequinEyes[1].GetComponent<Renderer>();
     }
 
     void Update()
@@ -28,9 +34,11 @@ public class ActivateMannequin : MonoBehaviour
         {
             if (MannequinAnimator != null)
             {
-                // 마네킹 애니메이션 재생
+                // 마네킹 애니메이션 재생 및 눈 색깔 변경
                 isAnimationActivated = true;
                 MannequinAnimator.Play("scare_mnq");
+                LeftMERenderer.material = MannequinEyesMaterial[1];
+                RightMERenderer.material = MannequinEyesMaterial[1];
 
                 // 3초 후에 상태 변경
                 StartCoroutine(ChangeStateAfterDelay(3f));
@@ -53,6 +61,10 @@ public class ActivateMannequin : MonoBehaviour
         // Animator의 상태를 변경
         MannequinAnimator.Play("idle_mnq");
         isAnimationActivated = false;
+
+        // 마네킹 눈 색깔을 원래대로 변경
+        LeftMERenderer.material = MannequinEyesMaterial[0];
+        RightMERenderer.material = MannequinEyesMaterial[0];
     }
 
 }

--- a/Assets/Scripts/ActivateSuitmans.cs
+++ b/Assets/Scripts/ActivateSuitmans.cs
@@ -32,7 +32,6 @@ public class ActivateSuitmans : MonoBehaviour
 
         if (Distance <= ActivationDistance && !isAnimationActivated)
         {
-            Debug.Log("Suitmans Enabled!");
             if (SuitManAnimators[0] != null)
             {
                 // 정장남 애니메이션 재생

--- a/Assets/Scripts/GamePlayManager.cs
+++ b/Assets/Scripts/GamePlayManager.cs
@@ -25,15 +25,15 @@ public class GamePlayManager : MonoBehaviour
     // 13번 ~ 17번 : 실험 사이클3
 
     int NumOfCorrectAnswer = 0; // 현재 맞춘 정답 개수
-    int[,] ExperimentAPArray = new int[2, 5]; // 스테이지별 등장시킬 이상현상 번호 or 일반 스테이지
+    int[,] ExperimentAPArray = new int[3, 5]; // 스테이지별 등장시킬 이상현상 번호 or 일반 스테이지
 
     public GameObject SafetyAlarmBoard;
     public GameObject StageInfoPanel;
     public GameObject PrevStageResultPanel;
     public GameObject NumOfCorrectAnswerPanel;
-    public Material[] StageInfoMaterial = new Material[14];
-    public Material[] PrevStageResultMaterial = new Material[2];
-    public Material[] NumOfCorrectAnswerMaterial = new Material[11];
+    public Material[] StageInfoMaterial = new Material[18]; // 스테이지 정보 패널 마테리얼 배열
+    public Material[] PrevStageResultMaterial = new Material[2]; // 이전 스테이지 정답 여부 패널 마테리얼 배열
+    public Material[] NumOfCorrectAnswerMaterial = new Material[16]; // 맞춘 정답 개수 패널 마테리얼 배령
 
     // Start is called before the first frame update
     void Start()
@@ -58,24 +58,23 @@ public class GamePlayManager : MonoBehaviour
         {
             NumOfCorrectAnswer++;
             if (CurrentStage == 1) NumOfCorrectAnswer--;
-            if (CurrentStage == 6)
+            if (CurrentStage == 6 || CurrentStage == 12)
             {
                 SafetyAlarmBoard.SetActive(true);
                 Debug.Log("안전알람 보드가 보여야돼요");
             }
-            if (CurrentStage == 7)
+            if (CurrentStage == 7 || CurrentStage == 13)
             {
                 NumOfCorrectAnswer--;
                 SafetyAlarmBoard.SetActive(false);
             }
             
-
-
-            if (CurrentStage == 12)
+            if (CurrentStage == 17)
             {
-                ElevatorDoor.SetActive(false);
                 EndGame();
             }
+
+
             else
             {
                 Debug.Log("정답!");
@@ -159,30 +158,33 @@ public class GamePlayManager : MonoBehaviour
 
     void LotteryPhenomenon() // VR 실험 버전에서 게임 시작 전, 스테이지별 이상현상 유무와 이상현상 종류를 미리 추첨하는 함수
     {
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < 3; i++)
         {
-            int NumOfNormalStage = Random.Range(0, 3);
-            bool isAddedPuzzleAP = false;
-
-            for (int j = 0; j < NumOfNormalStage; j++)
+            AbnormalNumber = Random.Range(0, 3);
+            if (!IsAbnormalOccured[AbnormalNumber])
             {
-                ExperimentAPArray[i, j] = -1;
+                ExperimentAPArray[i, 0] = AbnormalNumber;
+                IsAbnormalOccured[AbnormalNumber] = true;
             }
+            else i--;
+        }
 
-            for (int j = NumOfNormalStage; j < 5; j++)
+        bool isNormalStageAdded = false;
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 1; j <= 4; j++)
             {
-                // 퍼즐 유형 이상현상이 아직 추가되지 않았을 때 - 전체 이상현상에서 랜덤 추첨
-                if (!isAddedPuzzleAP)
+                AbnormalNumber = Random.Range(-1, 14);
+                if (AbnormalNumber == -1)
                 {
-                    AbnormalNumber = Random.Range(0, 13);
-                    if (AbnormalNumber <= 3 && !IsAbnormalOccured[AbnormalNumber]) isAddedPuzzleAP = true;
+                    if (!isNormalStageAdded)
+                    {
+                        ExperimentAPArray[i, j] = AbnormalNumber;
+                        isNormalStageAdded = true;
+                    }
+                    else j--;
                 }
-
-                // 퍼즐 유형 이상현상이 추가되었을 때 - 공포 유형 이상현상에서만 랜덤 추첨
-                else AbnormalNumber = Random.Range(4, 13);
-
-
-                if (!IsAbnormalOccured[AbnormalNumber])
+                else if (!IsAbnormalOccured[AbnormalNumber])
                 {
                     ExperimentAPArray[i, j] = AbnormalNumber;
                     IsAbnormalOccured[AbnormalNumber] = true;
@@ -190,6 +192,7 @@ public class GamePlayManager : MonoBehaviour
                 else j--;
             }
 
+            // 한번 더 섞기
             for (int j = 4; j > 0; j--)
             {
                 int k = Random.Range(0, j + 1);
@@ -248,7 +251,7 @@ public class GamePlayManager : MonoBehaviour
 
     void ChangePSRPanel(bool IsCorrect)
     {
-        if (CurrentStage == 7)
+        if (CurrentStage == 7 || CurrentStage == 13)
         {
             PrevStageResultPanel.SetActive(false);
             return;

--- a/Assets/Scripts/PhenomenonManagement.cs
+++ b/Assets/Scripts/PhenomenonManagement.cs
@@ -14,7 +14,7 @@ public class PhenomenonArr
 public class PhenomenonManagement : MonoBehaviour
 {
     // 이상현상 종류가 FixedType이냐, DynamicType이냐에 따라 작동방식에 차이를 줘야 할 듯.
-    public PhenomenonArr[] PhenomenonSpawner = new PhenomenonArr[20];
+    public PhenomenonArr[] PhenomenonSpawner = new PhenomenonArr[14];
     public bool IsNormal = true;
 
 


### PR DESCRIPTION
게임 시작전 랜덤으로 스테이지 이상현상 유무와 종류를 뽑는 방식을 변경하였습니다.
기존 : 1 ~11스테이지, 10개의 실험 스테이지 + 1개의 휴식 스테이지(6)
0~2개의 노멀 스테이지와 8개의 이상현상 스테이지로 구성, 이상현상 스테이지는 13개의 이상현상중 8~10개를 추첨하여
랜덤으로 배치.

현재 : 1 ~16스테이지, 15개의 실험 스테이지 + 2개의 휴식 스테이지(6, 12(
1개의 노멀 스테이지와 14개의 이상현상 스테이지로 구성, 이상현상 스테이지는 13 + 1(추가 예정), 14개의 이상현상을 추첨하여 랜덤으로 배치.


6번 이상현상(마네킹 애니메이션)에서 마네킹 애니메이션 작동시 마네킹의 눈이 빨갛게 바뀌는 기능을 추가하였습니다.