### PR TITLE
Perf | 이상현상 개선

### DIFF
--- a/Assets/Oculus/OculusProjectConfig.asset
+++ b/Assets/Oculus/OculusProjectConfig.asset
@@ -40,5 +40,5 @@ MonoBehaviour:
   systemSplashScreen: {fileID: 0}
   systemSplashScreenType: 0
   _systemLoadingScreenBackground: 0
-  ovrPluginMd5Win64: e8cfe66d40bc858ac6a51dd265d3b2f7a5d74d908cb85f302062be53066b513a
-  ovrPluginMd5Android: c7bb9a379e186c4b2726b69bbb7d3ace5f43eaf0cf503d035c25a6214a07807f
+  ovrPluginMd5Win64: e8cfe66d40bc858ac6a51dd265d3b2f7217666f91547fd4a1f31436d44725874
+  ovrPluginMd5Android: c7bb9a379e186c4b2726b69bbb7d3ace85a3382cb8154301df9545314995daa5

--- a/Assets/Scripts/ActivateMannequin.cs
+++ b/Assets/Scripts/ActivateMannequin.cs
@@ -5,18 +5,21 @@ using UnityEngine;
 public class ActivateMannequin : MonoBehaviour
 {
     public GameObject Player;
-    public float ActivationDistance = 50f; // 애니메이션 작동 범위
+    public float ActivationDistance = 40f; // 애니메이션 작동 범위
     public GameObject[] MannequinEyes = new GameObject[2];
     public Material[] MannequinEyesMaterial = new Material[2];
     public AudioSource MannequinSound;
-    bool isAnimationActivated = false;
+
+    private bool isAnimationActivated = false;
+    private float MoveDistance = 13f; // 이상현상 발생시 x축 대쉬 거리
+    private Vector3 OriginalPosition;
     private Animator MannequinAnimator;
     private Renderer LeftMERenderer;
     private Renderer RightMERenderer;
 
     void Start()
     {
-
+        OriginalPosition = transform.position;
     }
 
     private void OnEnable()
@@ -25,6 +28,7 @@ public class ActivateMannequin : MonoBehaviour
         MannequinAnimator = GetComponent<Animator>();
         LeftMERenderer = MannequinEyes[0].GetComponent<Renderer>();
         RightMERenderer = MannequinEyes[1].GetComponent<Renderer>();
+        OriginalPosition = transform.position;
     }
 
     private void OnDisable()
@@ -35,6 +39,7 @@ public class ActivateMannequin : MonoBehaviour
         RightMERenderer = MannequinEyes[1].GetComponent<Renderer>();
         LeftMERenderer.material = MannequinEyesMaterial[0];
         RightMERenderer.material = MannequinEyesMaterial[0];
+        transform.position = OriginalPosition;
     }
 
     void Update()
@@ -51,17 +56,13 @@ public class ActivateMannequin : MonoBehaviour
                 LeftMERenderer.material = MannequinEyesMaterial[1];
                 RightMERenderer.material = MannequinEyesMaterial[1];
                 Invoke("PlaySound", 0.5f);
-
+                StartCoroutine(MoveOverSeconds(gameObject, MoveDistance, 0.5f));
                 StartCoroutine(ChangeStateAfterDelay(3f));
             }
             else
             {
                 Debug.Log("MannequinAnimator를 찾을 수 없음");
             }
-        }
-        else
-        {
-            
         }
     }
 
@@ -78,14 +79,22 @@ public class ActivateMannequin : MonoBehaviour
 
     IEnumerator ChangeStateAfterDelay(float Delay)
     {
-        yield return new WaitForSeconds(Delay);
-
-        // Animator의 상태를 변경
+        yield return new WaitForSeconds(Delay);    
         StopSound();
-
-        // 마네킹 눈 색깔을 원래대로 변경
-        // LeftMERenderer.material = MannequinEyesMaterial[0];
-        // RightMERenderer.material = MannequinEyesMaterial[0];
     }
 
+    IEnumerator MoveOverSeconds(GameObject ObjectToMove, float distance, float seconds)
+    {
+        float ElapsedTime = 0;
+        Vector3 StartPosition = ObjectToMove.transform.position;
+        Vector3 TargetPosition = new Vector3(StartPosition.x + distance, StartPosition.y, StartPosition.z);
+
+        while (ElapsedTime < seconds)
+        {
+            ObjectToMove.transform.position = Vector3.Lerp(StartPosition, TargetPosition, (ElapsedTime / seconds));
+            ElapsedTime += Time.deltaTime;
+            yield return null;
+        }
+        ObjectToMove.transform.position = TargetPosition;
+    }
 }

--- a/Assets/Scripts/ActivateSuitmans.cs
+++ b/Assets/Scripts/ActivateSuitmans.cs
@@ -8,8 +8,8 @@ public class ActivateSuitmans : MonoBehaviour
     public GameObject[] SuitMans = new GameObject[5];
     bool isAnimationActivated = false;
     private Animator[] SuitManAnimators = new Animator[5];
-    private float ActivationDistance = 60f; // 애니메이션 작동 범위
-    private float MoveDistance = 40f; // 정장남 이동 거리
+    private float ActivationDistance = 50f; // 애니메이션 작동 범위
+    private float MoveDistance = 30f; // 정장남 이동 거리
     // Start is called before the first frame update
     void Start()
     {
@@ -42,8 +42,6 @@ public class ActivateSuitmans : MonoBehaviour
                     Debug.Log("춤추는 애니메이션 재생");
                 }
                 MoveSuitMans();
-                // 4초 후에 상태 변경
-                // StartCoroutine(ChangeStateAfterDelay(0.6f));
             }
             else
             {
@@ -81,6 +79,5 @@ public class ActivateSuitmans : MonoBehaviour
         {
             SuitManAnimators[i].Play("stand_suit");
         }
-        // isAnimationActivated = false;
     }
 }

--- a/Assets/Scripts/GamePlayManager.cs
+++ b/Assets/Scripts/GamePlayManager.cs
@@ -159,7 +159,7 @@ public class GamePlayManager : MonoBehaviour
 
     public void ResetTeleport()
     {
-        Debug.Log("5초 후 CanTeleport 리셋");
+        Debug.Log("텔레포트 활성화");
         CanTeleport = true;
     }
 

--- a/Assets/Scripts/SpawnManagerDynamicType.cs
+++ b/Assets/Scripts/SpawnManagerDynamicType.cs
@@ -24,14 +24,14 @@ public class SpawnManagerDynamicType : MonoBehaviour
 
     private int phenomenonNumber = -1;
     private bool IsCoroutineRunning = false;
-    // Start is called before the first frame update
+    private Coroutine CurrentFloorCoroutine = null;
+
     void Start()
     {
         ghostAudioSource = GhostSound.GetComponent<AudioSource>();
         ceilAudioSource = CeilSound.GetComponent<AudioSource>();
     }
 
-    // Update is called once per frame
     void Update()
     {
         
@@ -139,19 +139,18 @@ public class SpawnManagerDynamicType : MonoBehaviour
     // 바닥이 올라오는 이상현상
     public void ComeUpFloor(bool isNormal)
     {
+        if (CurrentFloorCoroutine != null)
+        {
+            StopCoroutine(CurrentFloorCoroutine);
+        }
+
         if (!isNormal)
         {
-            if (!IsCoroutineRunning)
-            {
-                StartCoroutine(MoveFloorUp());
-            }
+            CurrentFloorCoroutine = StartCoroutine(MoveFloorUp());
         }
         else
         {
-            if (!IsCoroutineRunning)
-            {
-                StartCoroutine(MoveFloorDown());
-            }
+            CurrentFloorCoroutine = StartCoroutine(MoveFloorDown());
         }
     }
     // 으스스한 귀신 사운드 재생 이상현상

--- a/Assets/Scripts/SpawnManagerDynamicType.cs
+++ b/Assets/Scripts/SpawnManagerDynamicType.cs
@@ -23,7 +23,6 @@ public class SpawnManagerDynamicType : MonoBehaviour
     private AudioSource ceilAudioSource;
 
     private int phenomenonNumber = -1;
-    private bool IsCoroutineRunning = false;
     private Coroutine CurrentFloorCoroutine = null;
 
     void Start()
@@ -156,7 +155,6 @@ public class SpawnManagerDynamicType : MonoBehaviour
     // 으스스한 귀신 사운드 재생 이상현상
     public void PlayGhostSound(bool isNormal)
     {
-        
         if (isNormal)
         {
             
@@ -225,8 +223,6 @@ public class SpawnManagerDynamicType : MonoBehaviour
 
     IEnumerator MoveFloorUp()
     {
-        IsCoroutineRunning = true;
-
         while (Floor.transform.position.y < 2)
         {
             Vector3 NewPosition = Floor.transform.position + Vector3.up * Time.deltaTime;
@@ -238,13 +234,10 @@ public class SpawnManagerDynamicType : MonoBehaviour
             yield return null;
         }
 
-        IsCoroutineRunning = false;
     }
 
     IEnumerator MoveFloorDown()
     {
-        IsCoroutineRunning = true;
-
         while (Floor.transform.position.y > -5)
         {
             Vector3 NewPosition = Floor.transform.position + Vector3.down * Time.deltaTime;
@@ -255,8 +248,6 @@ public class SpawnManagerDynamicType : MonoBehaviour
 
             yield return null;
         }
-
-        IsCoroutineRunning = false;
     }
 
     IEnumerator PlayGhostSoundAfterDelay(float delay)

--- a/Assets/Scripts/TeleportZone.cs
+++ b/Assets/Scripts/TeleportZone.cs
@@ -10,7 +10,7 @@ public class TeleportZone : MonoBehaviour
     public GameObject TutorialGuide2;
     public Transform Destination;
     public bool IsFront;
-    public float CoolDown = 3f;
+    public float CoolDown = 1f;
 
     // Start is called before the first frame update
     void Start()


### PR DESCRIPTION
전반적인 이상현상 개선을 진행했습니다.
1. 바닥 융기 이상현상에서 상승 Coroutine이 끝나기 전에 사용자가 전진 또는 후진하여 텔레포트를 하면 하강 Coroutine이 실행되지 않던 문제를 해결했습니다.
2. 바닥 융기 이상현상에서 SignUp에 플레이어가 가로막혀 이동에 불편함을 초래했던 문제를 해결했습니다.
3. 정장남 이상현상에서 플레이어의 감지거리와 대쉬거리를 기존 (60f, 40f)에서 (50f, 30f)로 변경했습니다.
4. 마네킹 이상현상에서 감지거리 안에 플레이어가 들어오면 복도 중앙으로 대시하는 현상을 추가했습니다.
5. 편의점 이상현상 정답률이 현저히 낮고, 편의점 내부를 플레이어가 둘러보는 경향이 적어 편의점 내부에 약한 조명 1개를 추가했습니다.